### PR TITLE
add a log for vault config

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func processVaultAddress(githubToken string, ce AmanarConfigurationElement) {
 			continue
 		}
 
+		log.Printf("[VAULT CONFIGURATION] %v:%v", configItem.VaultPath, configItem.VaultRole)
 		ProcessConfigItem(&configItem.Configurables, credentials)
 	}
 }


### PR DESCRIPTION
This way after running the command it is obvious which DB each output is for. I find this useful when in addition to the configured output target I also want to copy the credentials somewhere else. So far I've been sort of remembering their order in my config, but this makes it immediately clear.